### PR TITLE
Status for Database connection status

### DIFF
--- a/oqtopus/ui/database_connection_widget.ui
+++ b/oqtopus/ui/database_connection_widget.ui
@@ -65,7 +65,7 @@
    <item row="3" column="0">
     <widget class="QLabel" name="label_11">
      <property name="text">
-      <string>Module info</string>
+      <string>Status</string>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
`Status` instead of `Module info` for Database connection status

Last item of https://github.com/opengisch/oqtopus/issues/17
