### PR TITLE
Better document DB create dialog / fix DB name for "Enter manually"

### DIFF
--- a/oqtopus/gui/database_create_dialog.py
+++ b/oqtopus/gui/database_create_dialog.py
@@ -73,8 +73,6 @@ class DatabaseCreateDialog(QDialog, DIALOG_UI):
         self.parameters_port_lineEdit.setPlaceholderText(DEFAULT_PG_PORT)
         self.parameters_database_lineEdit.setPlaceholderText(DEFAULT_PG_DB)
 
-        self.database_lineEdit.textChanged.connect(self._databaseTextChanged)
-
         self.buttonBox.accepted.connect(self._accept)
 
         if self.existingService_comboBox.count() > 0:
@@ -105,9 +103,6 @@ class DatabaseCreateDialog(QDialog, DIALOG_UI):
 
     def _enterManuallyToggled(self, checked):
         self.parameters_frame.setEnabled(checked)
-
-    def _databaseTextChanged(self, text):
-        self.database_label.setText(text)
 
     def _accept(self):
         service_name = self.created_service_name()
@@ -193,9 +188,10 @@ class DatabaseCreateDialog(QDialog, DIALOG_UI):
             service_name = self.existingService_comboBox.currentText()
             existing_settings = pgserviceparser_service_config(service_name)
             settings.update(existing_settings)
-            # Overwrite dbname with the new database name
-            if self.database_lineEdit.text():
-                settings["dbname"] = self.database_lineEdit.text()
+
+        # Overwrite dbname with the new database name
+        if self.database_lineEdit.text():
+            settings["dbname"] = self.database_lineEdit.text()
 
         return settings
 

--- a/oqtopus/ui/database_create_dialog.ui
+++ b/oqtopus/ui/database_create_dialog.ui
@@ -11,13 +11,16 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Create Service</string>
+   <string>Create Database</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <widget class="QGroupBox" name="groupBox_2">
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;To issue a &lt;span style=&quot; font-style:italic;&quot;&gt;CREATE DATABASE&lt;/span&gt; command, you must first be connected to the PostgreSQL server. Select an existing administrative connection (often named postgres) from a service or manually.&lt;br/&gt;This connection is used to perform the creation action, and as a template for the new service to be created.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
      <property name="title">
-      <string>Create database</string>
+      <string>Connection to use</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_2">
       <item row="0" column="1">
@@ -164,25 +167,6 @@
         </attribute>
        </widget>
       </item>
-      <item row="6" column="1">
-       <widget class="QLineEdit" name="database_lineEdit">
-        <property name="font">
-         <font>
-          <italic>false</italic>
-         </font>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-       </widget>
-      </item>
-      <item row="6" column="0">
-       <widget class="QLabel" name="label_4">
-        <property name="text">
-         <string>Database</string>
-        </property>
-       </widget>
-      </item>
       <item row="0" column="0">
        <widget class="QRadioButton" name="useService_radioButton">
         <property name="text">
@@ -202,35 +186,48 @@
    <item>
     <widget class="QGroupBox" name="groupBox">
      <property name="title">
-      <string>Create service</string>
+      <string>New database</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_3">
-      <item row="0" column="0">
+      <item row="1" column="0">
        <widget class="QLabel" name="label">
+        <property name="toolTip">
+         <string>Enter a convenient alias that will be created in your pg_service.conf file.</string>
+        </property>
         <property name="text">
-         <string>Service</string>
+         <string>Service name</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QLineEdit" name="service_lineEdit">
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enter a convenient alias that will be created in your &lt;span style=&quot; font-style:italic;&quot;&gt;pg_service.conf&lt;/span&gt; file.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_4">
+        <property name="toolTip">
+         <string>Enter the actual name for the new database as it will exist inside your PostgreSQL installation.</string>
+        </property>
+        <property name="text">
+         <string>Database name</string>
         </property>
        </widget>
       </item>
       <item row="0" column="1">
-       <widget class="QLineEdit" name="service_lineEdit"/>
-      </item>
-      <item row="1" column="1">
-       <widget class="QLabel" name="database_label">
+       <widget class="QLineEdit" name="database_lineEdit">
         <property name="font">
          <font>
-          <italic>true</italic>
+          <italic>false</italic>
          </font>
         </property>
-        <property name="text">
-         <string>-</string>
+        <property name="toolTip">
+         <string>Enter the actual name for the new database as it will exist inside your PostgreSQL installation.</string>
         </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_2">
         <property name="text">
-         <string>Database</string>
+         <string/>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
- Better separate connection to use / New database
- Dialog title to "Create Database"
- Tooltip documentation
  - **Connection to use:** see screenshot
  - **New Database name:** Enter the actual name for the new database as it will exist inside your PostgreSQL installation.
  - **New service name:** Enter a convenient alias that will be created in your pg_service.conf file.
- Fix wrong database name used in service for "Enter manually"


<img width="754" height="569" alt="image" src="https://github.com/user-attachments/assets/34a6fdfb-843e-4380-a41c-d771da3c3856" />



Previous look:
<img width="514" height="574" alt="Screenshot_2025-08-04_09 21 09" src="https://github.com/user-attachments/assets/ceec7344-9d44-4a22-88f7-8e097e39ce66" />

