### PR TITLE
Handle change of QAction module from qt5 to qt6

### DIFF
--- a/oqtopus/gui/database_connection_widget.py
+++ b/oqtopus/gui/database_connection_widget.py
@@ -3,7 +3,13 @@ from pgserviceparser import conf_path as pgserviceparser_conf_path
 from pgserviceparser import service_config as pgserviceparser_service_config
 from pgserviceparser import service_names as pgserviceparser_service_names
 from qgis.PyQt.QtCore import pyqtSignal
-from qgis.PyQt.QtGui import QAction
+
+try:
+    from qgis.PyQt.QtGui import QAction
+except ImportError:
+    # Import for Qt5
+    from qgis.PyQt.QtWidgets import QAction
+
 from qgis.PyQt.QtWidgets import QDialog, QMenu, QWidget
 
 from ..utils.plugin_utils import PluginUtils, logger

--- a/oqtopus/gui/main_dialog.py
+++ b/oqtopus/gui/main_dialog.py
@@ -27,7 +27,14 @@ import os
 import sys
 
 from qgis.PyQt.QtCore import QUrl
-from qgis.PyQt.QtGui import QAction, QDesktopServices
+from qgis.PyQt.QtGui import QDesktopServices
+
+try:
+    from qgis.PyQt.QtGui import QAction
+except ImportError:
+    # Import for Qt5
+    from qgis.PyQt.QtWidgets import QAction
+
 from qgis.PyQt.QtWidgets import (
     QDialog,
     QMenuBar,


### PR DESCRIPTION
This is needed when running oqtopus standalone with Qt5