### PR TITLE
Propose similar formulations for oQtopus about sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 <img src="oqtopus/icons/oqtopus-logo.png" alt="logo" width="250"/>
 
-Front-end application to manage [PUM](https://github.com/opengisch/pum) modules.
+oQtopus : A QGIS module manager that helps you deploy, manage and upgrade your QGIS projects, plugins and associated postgreSQL / PostGIS datamodel implementations.
+
+Installation and upgrade* of your datamodel implementations are managed through the PostgreSQL Upgrade Manager ([PUM](https://github.com/opengisch/pum)).
 
 Read the docs: https://opengisch.github.io/oqtopus/
+
+*upgrade is currently reaching the development phase, this feature will be available soon. Check [here](linktobedefine) to contribute!

--- a/docs/docs/getting_started.md
+++ b/docs/docs/getting_started.md
@@ -1,7 +1,12 @@
 # Getting Started
 
-oQtopus is designed to deploy PostgreSQL modules managed by [pum](https://github.com/opengisch/pum/) along with a QGIS project and plugin.
+oQtopus is designed to deploy, manage and upgrade QGIS projects and plugins along with their associated postgreSQL / PostGIS datamodel implementations.
+
+Installation and upgrade* of your datamodel implementations are managed through the PostgreSQL Upgrade Manager ([pum](https://github.com/opengisch/pum/)).
+
 It can be installed either as a QGIS plugin or as a standalone Python executable.
+
+*Upgrade functionnality has now reach the development phase, it should be available in the next months.
 
 ## oQtopus as a QGIS Plugin
 

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -4,6 +4,10 @@
 
 # oQtopus
 
-oQtopus is an open-source platform designed to simplify and automate the deployment and management of PostgreSQL/postgis modules with QGIS projects.
+oQtopus is designed to deploy, manage and upgrade QGIS projects and plugins along with their associated postgreSQL / PostGIS datamodel implementations.
 
-![oqtopus_start_screen](./assets/images/oqtopus_start_screen.png){: style="width:800px"}
+Installation and upgrade* of your datamodel implementations are done through the PostgreSQL Upgrade Manager [pum](https://github.com/opengisch/pum/).
+
+It is open source and can be used as a QGIS plugin or a standalone tool.
+
+*Upgrade functionnality has now reach the development phase, it should be available in the next months.

--- a/oqtopus/metadata.txt
+++ b/oqtopus/metadata.txt
@@ -1,12 +1,12 @@
 [general]
-name=oQtopus Module Management Tool
+name=oQtopus
 qgisMinimumVersion=3.0
-description=This is the management tool for every PUM based module installation and upgrade
+description=oQtopus : A QGIS module manager that helps you deploy, manage and upgrade your QGIS projects, plugins and associated postgreSQL / PostGIS datamodel implementations.
 version=0.1
 author=OPENGIS.ch
 email=info@opengis.ch
 
-about=This is the management tool for every PUM based module installation and upgrade
+about=oQtopus : A QGIS module manager that helps you deploy, manage and upgrade your QGIS projects, plugins and associated postgreSQL / PostGIS datamodel implementations
 homepage=https://opengisch.github.io/oqtopus
 tracker=https://github.com/opengisch/oqtopus/issues
 repository=https://github.com/opengisch/oqtopus

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,8 +7,8 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "oqtopus"
-description = "A QGIS module manager"
-dynamic = ["version", "dependencies"]
+description = "oQtopus : A QGIS module manager that helps you deploy, manage and upgrade your QGIS projects, plugins and associated postgreSQL / PostGIS data model implementations"
+dynamic = ["version"]
 readme = "README.md"
 requires-python = ">=3.8"
 license = { file = "LICENSE" }


### PR DESCRIPTION
Propose similar formulations for oQtopus about sections :


1. oQtopus is designed to deploy, manage and upgrade QGIS projects and plugins along with their associated postgreSQL / PostGIS datamodel implementations.

2. Installation and upgrade* of your datamodel implementations are done through the PostgreSQL Upgrade Manager [pum](https://github.com/opengisch/pum/).

3. It is open source and can be used as a QGIS plugin or a standalone tool.

4. *upgrade is currently reaching the development phase, this feature will be available soon. Check [here](linktobedefine) to contribute!