### PR TITLE
Improve database and service management UI

### DIFF
--- a/oqtopus/gui/database_connection_widget.py
+++ b/oqtopus/gui/database_connection_widget.py
@@ -4,7 +4,14 @@ import sys
 import psycopg
 from qgis.PyQt.QtCore import pyqtSignal
 from qgis.PyQt.QtGui import QAction
-from qgis.PyQt.QtWidgets import QDialog, QLabel, QMenu, QVBoxLayout, QWidget
+from qgis.PyQt.QtWidgets import (
+    QDialog,
+    QLabel,
+    QMenu,
+    QMessageBox,
+    QVBoxLayout,
+    QWidget,
+)
 
 from ..libs.pgserviceparser import conf_path as pgserviceparser_conf_path
 from ..libs.pgserviceparser import service_config as pgserviceparser_service_config
@@ -42,7 +49,7 @@ class DatabaseConnectionWidget(QWidget, DIALOG_UI):
         db_operations_menu = QMenu(self.db_operations_toolButton)
 
         actionManagePgServices = QAction(self.tr("Manage PG services"), db_operations_menu)
-        actionCreateDb = QAction(self.tr("Create database"), db_operations_menu)
+        actionCreateDb = QAction(self.tr("Create database and service"), db_operations_menu)
         self.__actionDuplicateDb = QAction(self.tr("Duplicate database"), db_operations_menu)
         actionReloadPgServices = QAction(self.tr("Reload PG Service config"), db_operations_menu)
 
@@ -59,6 +66,22 @@ class DatabaseConnectionWidget(QWidget, DIALOG_UI):
         db_operations_menu.addAction(actionReloadPgServices)
 
         self.db_operations_toolButton.setMenu(db_operations_menu)
+
+        # Service-specific operations menu (next to service combobox)
+        service_menu = QMenu(self.db_service_toolButton)
+        self.__actionCreateDbForService = QAction(self.tr("Create database"), service_menu)
+        self.__actionDropDb = QAction(self.tr("Drop database"), service_menu)
+
+        self.__actionCreateDbForService.triggered.connect(self.__createDatabaseForServiceClicked)
+        self.__actionDropDb.triggered.connect(self.__dropDatabaseClicked)
+
+        service_menu.addAction(self.__actionCreateDbForService)
+        service_menu.addAction(self.__actionDropDb)
+
+        self.db_service_toolButton.setMenu(service_menu)
+
+        self.__actionCreateDbForService.setDisabled(True)
+        self.__actionDropDb.setDisabled(True)
 
         self.__database_connection = None
         self.__installed_module_ids = []
@@ -119,6 +142,8 @@ class DatabaseConnectionWidget(QWidget, DIALOG_UI):
             QtUtils.setFontItalic(self.db_database_label, True)
 
             self.__actionDuplicateDb.setDisabled(True)
+            self.__actionCreateDbForService.setDisabled(True)
+            self.__actionDropDb.setDisabled(True)
 
             self.__set_connection(None)
             return
@@ -134,6 +159,8 @@ class DatabaseConnectionWidget(QWidget, DIALOG_UI):
             QtUtils.setFontItalic(self.db_database_label, True)
 
             self.__actionDuplicateDb.setDisabled(True)
+            self.__actionCreateDbForService.setEnabled(True)
+            self.__actionDropDb.setDisabled(True)
             return
 
         self.db_database_label.setText(service_database)
@@ -150,11 +177,17 @@ class DatabaseConnectionWidget(QWidget, DIALOG_UI):
         except Exception as exception:
             self.__set_connection(None)
 
+            self.__actionCreateDbForService.setEnabled(True)
+            self.__actionDropDb.setDisabled(True)
+
             self.db_moduleInfo_label.setText("Can't connect to service.")
             QtUtils.setForegroundColor(self.db_moduleInfo_label, PluginUtils.COLOR_WARNING)
             errorText = self.tr(f"Can't connect to service '{service_name}':\n{exception}.")
             logger.error(errorText)
             return
+
+        self.__actionCreateDbForService.setDisabled(True)
+        self.__actionDropDb.setEnabled(True)
 
         self.db_moduleInfo_label.setText("Connected.")
         logger.info(f"Connected to service '{service_name}'.")
@@ -287,6 +320,74 @@ class DatabaseConnectionWidget(QWidget, DIALOG_UI):
             layout.addWidget(label)
 
         self.installed_modules_groupbox.setVisible(True)
+
+    def __createDatabaseForServiceClicked(self):
+        service_name = self.db_services_comboBox.currentText()
+        if not service_name or self.db_services_comboBox.currentData() is None:
+            return
+
+        databaseCreateDialog = DatabaseCreateDialog(
+            selected_service=service_name,
+            fixed_service_name=service_name,
+            parent=self,
+        )
+
+        if databaseCreateDialog.exec() == QDialog.DialogCode.Rejected:
+            return
+
+        self.__loadDatabaseInformations()
+        self.db_services_comboBox.setCurrentText(service_name)
+
+    def __dropDatabaseClicked(self):
+        service_name = self.db_services_comboBox.currentText()
+        if not service_name or self.db_services_comboBox.currentData() is None:
+            return
+
+        service_config = pgserviceparser_service_config(service_name)
+        db_name = service_config.get("dbname")
+        if not db_name:
+            MessageBar.pushWarningToBar(
+                self, self.tr("No database name configured for this service.")
+            )
+            return
+
+        reply = QMessageBox.question(
+            self,
+            self.tr("Drop database"),
+            self.tr(
+                f"Are you sure you want to drop the database '{db_name}'?\n\n"
+                "This action cannot be undone!"
+            ),
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            QMessageBox.StandardButton.No,
+        )
+        if reply != QMessageBox.StandardButton.Yes:
+            return
+
+        # Close existing connection (cannot drop while connected)
+        self.__set_connection(None)
+
+        try:
+            conn = psycopg.connect(service=service_name, dbname="postgres")
+            conn.autocommit = True
+            with conn.cursor() as cursor:
+                # Terminate other connections to the database
+                cursor.execute(
+                    "SELECT pg_terminate_backend(pid) "
+                    "FROM pg_stat_activity "
+                    "WHERE datname = %s AND pid <> pg_backend_pid()",
+                    [db_name],
+                )
+                cursor.execute(
+                    psycopg.sql.SQL("DROP DATABASE {}").format(psycopg.sql.Identifier(db_name))
+                )
+            conn.close()
+
+            MessageBar.pushSuccessToBar(self, self.tr(f"Database '{db_name}' has been dropped."))
+        except Exception as e:
+            MessageBar.pushErrorToBar(self, self.tr(f"Failed to drop database: {e}"))
+
+        self.__serviceChanged()
 
     def __set_connection(self, connection):
         """

--- a/oqtopus/gui/database_create_dialog.py
+++ b/oqtopus/gui/database_create_dialog.py
@@ -24,13 +24,14 @@
 
 import psycopg
 from qgis.PyQt.QtCore import Qt
-from qgis.PyQt.QtWidgets import QDialog, QMessageBox
+from qgis.PyQt.QtWidgets import QDialog, QVBoxLayout
 
 from ..libs.pgserviceparser import service_config as pgserviceparser_service_config
 from ..libs.pgserviceparser import service_names as pgserviceparser_service_names
 from ..libs.pgserviceparser import write_service as pgserviceparser_write_service
 from ..utils.plugin_utils import PluginUtils, logger
 from ..utils.qt_utils import OverrideCursor
+from .message_bar import MessageBar
 
 DIALOG_UI = PluginUtils.get_ui_class("database_create_dialog.ui")
 
@@ -41,9 +42,17 @@ DEFAULT_PG_HOST = "localhost"
 
 
 class DatabaseCreateDialog(QDialog, DIALOG_UI):
-    def __init__(self, selected_service=None, parent=None):
+    def __init__(self, selected_service=None, fixed_service_name=None, parent=None):
         QDialog.__init__(self, parent)
         self.setupUi(self)
+
+        self.__fixed_service = fixed_service_name is not None
+
+        # Message bar at top of dialog
+        self.__message_bar = MessageBar(self)
+        placeholder_layout = QVBoxLayout(self.messageBar_placeholder)
+        placeholder_layout.setContentsMargins(0, 0, 0, 0)
+        placeholder_layout.addWidget(self.__message_bar)
 
         self.existingService_comboBox.clear()
         for service_name in pgserviceparser_service_names():
@@ -78,6 +87,15 @@ class DatabaseCreateDialog(QDialog, DIALOG_UI):
         if self.existingService_comboBox.count() > 0:
             self._serviceChanged()
 
+        if fixed_service_name:
+            self.service_lineEdit.setText(fixed_service_name)
+            self.service_lineEdit.setReadOnly(True)
+            # Prefill database name from existing service config
+            svc_cfg = pgserviceparser_service_config(fixed_service_name)
+            dbname = svc_cfg.get("dbname")
+            if dbname:
+                self.database_lineEdit.setText(dbname)
+
     def created_service_name(self):
         return self.service_lineEdit.text()
 
@@ -108,20 +126,38 @@ class DatabaseCreateDialog(QDialog, DIALOG_UI):
         service_name = self.created_service_name()
 
         if service_name == "":
-            QMessageBox.critical(self, "Error", "Please enter a service name.")
-            return
-
-        # Check if the service name is already in use
-        if service_name in pgserviceparser_service_names():
-            QMessageBox.critical(
-                self, "Error", self.tr(f"Service name '{service_name}' already exists.")
-            )
+            self.__message_bar.pushError(self.tr("Please enter a service name."))
             return
 
         new_database_name = self.database_lineEdit.text()
         if new_database_name == "":
-            QMessageBox.critical(self, "Error", "Please enter a database name.")
+            self.__message_bar.pushError(self.tr("Please enter a database name."))
             return
+
+        # If the service already exists, check that the connection config matches
+        service_already_exists = service_name in pgserviceparser_service_names()
+        if service_already_exists and not self.__fixed_service:
+            existing = pgserviceparser_service_config(service_name)
+            intended = self._get_new_service_settings()
+            # Compare connection-relevant keys (ignore dbname since that's the new one)
+            _COMPARE_KEYS = ("host", "port", "user", "password", "sslmode")
+            mismatches = []
+            for key in _COMPARE_KEYS:
+                existing_val = existing.get(key, "")
+                intended_val = intended.get(key, "")
+                if existing_val != intended_val:
+                    mismatches.append(
+                        f"  {key}: existing='{existing_val}', entered='{intended_val}'"
+                    )
+            if mismatches:
+                self.__message_bar.pushError(
+                    self.tr(
+                        "Service '{service}' already exists with a different configuration:\n"
+                        "{details}\n\n"
+                        "Please use a different service name or adjust the parameters."
+                    ).format(service=service_name, details="\n".join(mismatches))
+                )
+                return
 
         database_connection = None
         try:
@@ -138,14 +174,14 @@ class DatabaseCreateDialog(QDialog, DIALOG_UI):
         except Exception as e:
             errorText = self.tr(f"Error creating the new database:\n{e}.")
             logger.error(errorText)
-            QMessageBox.critical(self, "Error", errorText)
+            self.__message_bar.pushError(errorText)
             return
 
         finally:
             if database_connection:
                 database_connection.close()
 
-        # Proceed with writing the new service configuration
+        # Write or update the service configuration
         service_settings = self._get_new_service_settings()
 
         try:
@@ -155,9 +191,9 @@ class DatabaseCreateDialog(QDialog, DIALOG_UI):
                 create_if_not_found=True,
             )
         except Exception as e:
-            errorText = self.tr(f"Error writing the new service configuration:\n{e}.")
+            errorText = self.tr(f"Error writing the service configuration:\n{e}.")
             logger.error(errorText)
-            QMessageBox.critical(self, "Error", errorText)
+            self.__message_bar.pushError(errorText)
             return
 
         super().accept()
@@ -175,6 +211,11 @@ class DatabaseCreateDialog(QDialog, DIALOG_UI):
             service_name = self.existingService_comboBox.currentText()
             if service_name:
                 settings["service"] = service_name
+
+        # When creating for a fixed service, override dbname so we can connect
+        # even if the target database doesn't exist yet.
+        if self.__fixed_service:
+            settings["dbname"] = "postgres"
 
         return settings
 

--- a/oqtopus/ui/database_connection_widget.ui
+++ b/oqtopus/ui/database_connection_widget.ui
@@ -85,6 +85,16 @@
      </item>
     </widget>
    </item>
+   <item row="1" column="2">
+    <widget class="QToolButton" name="db_service_toolButton">
+     <property name="text">
+      <string>...</string>
+     </property>
+     <property name="popupMode">
+      <enum>QToolButton::InstantPopup</enum>
+     </property>
+    </widget>
+   </item>
    <item row="0" column="1">
     <widget class="QLabel" name="db_servicesConfigFilePath_label">
      <property name="font">

--- a/oqtopus/ui/database_create_dialog.ui
+++ b/oqtopus/ui/database_create_dialog.ui
@@ -11,9 +11,12 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Create Database</string>
+   <string>Create database and service</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QWidget" name="messageBar_placeholder" native="true"/>
+   </item>
    <item>
     <widget class="QGroupBox" name="groupBox_2">
      <property name="toolTip">

--- a/oqtopus/ui/main_dialog.ui
+++ b/oqtopus/ui/main_dialog.ui
@@ -20,7 +20,7 @@
    <item row="1" column="0" rowspan="2">
     <widget class="QGroupBox" name="db_groupBox">
      <property name="title">
-      <string>Database connection</string>
+      <string>Database and service</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_5"/>
     </widget>


### PR DESCRIPTION
- Rename 'Database connection' groupbox to 'Database and service'
- Rename create dialog title to 'Create database and service'

Database create dialog:
- Replace QMessageBox with MessageBar (QgsMessageBar in QGIS, custom fallback)
- Add fixed_service_name parameter: prefills service name (readonly) and database name from existing service config
- When a service name already exists, compare connection-relevant keys (host, port, user, password, sslmode) and allow reuse if they match, otherwise show a detailed mismatch error

Service-specific operations:
- Add a toolbutton with menu next to the service combobox
- 'Create database' action: opens create dialog with the current service prefilled and readonly, enabled when service is selected but DB connection fails
- 'Drop database' action: confirms via dialog, terminates other connections, drops the database, enabled only when connected


fixes #119