### PR TITLE
revert too hard evolution of pydantic requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 PyYAML
-pydantic >=2.13.3
+pydantic>=2.12.5<3.0.0
 psycopg>=3.2.13,<4.0.0
 requests>=2.32.5,<3.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 PyYAML
-pydantic>=2.12.5<3.0.0
+pydantic>=2.12.5,<3.0.0
 psycopg>=3.2.13,<4.0.0
 requests>=2.32.5,<3.0.0


### PR DESCRIPTION
If it doesn't break anything it would at least not break working configurations